### PR TITLE
Replace consecutive separators with one

### DIFF
--- a/src/FrontendLoader.php
+++ b/src/FrontendLoader.php
@@ -94,7 +94,7 @@ class FrontendLoader
     {
         $out = strtolower($str);
         $out = preg_replace('/[^a-z0-9' . $separator . ']/', $separator, $out);
-        $out = preg_replace('/[' . $separator . ']{2,}/', '', $out);
+        $out = preg_replace('/[' . $separator . ']{2,}/', $separator, $out);
         $out = preg_replace('/^' . $separator . '/', '', $out);
         $out = preg_replace('/' . $separator . '$/', '', $out);
         return $out;


### PR DESCRIPTION
Current implementation of machine() replaces multiple consecutive separators with an empty string. The desired result is probably to replace them with one separator, instead of none.
